### PR TITLE
Add keepalive workflow to prevent auto-disable

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,15 @@
+name: Keepalive
+run-name: Keep repository active so scheduled workflows aren't auto-disabled
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
GitHub auto-disables scheduled workflows after 60 days of inactivity.
This monthly job pushes a no-op commit to keep the repo active.